### PR TITLE
Always emit log event if there is a listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,10 @@ Possible formats:
 
 ### Events
 
-Each log level will emit an event of the same name *if the log level is high enough*.
-For example, `logger.critical('foo');` will emit a `'critical'` event whose
-callback argument will be of type `Log`.
+Each log level will emit an event of the same name _if the log level is high enough_. For example, `logger.critical('foo');` will emit a `'critical'` event whose
+callback argument will be of type `Log`. This way, applications can hook in to the logging system and respond however they want (post to Slack, send to a logging service, etc.).
 
-This way, applications can hook in to the logging system and respond however
-they want (post to Slack, send to a logging service, etc.).
+In addition, emit a `log` event when any log is received *if there is a listener to the event*. This event will be passed with args `level`, `formattedLog`, and `rawLog`. Code can hook into these events to forward logs or ensure that logs are being added even if it is not being written to `stdout`/`stderr`.
 
 ### Streaming
 

--- a/lib/jobi.js
+++ b/lib/jobi.js
@@ -133,11 +133,15 @@ class Jobi extends EventEmitter {
     const levelValue = levels[ level ];
 
     // Ignore invalid or insufficient log levels
-    if (
-      levelValue === undefined ||
-      this.level === undefined ||
-      levelValue < levels[ this.level ]
-    ) {
+    const shouldLog =
+      levelValue !== undefined &&
+      this.level !== undefined &&
+      levelValue >= levels[ this.level ];
+
+    const shouldEmit = this.listenerCount('log') > 0;
+
+    // Return early if no action is required
+    if ( !shouldLog && !shouldEmit ) {
       return;
     }
 
@@ -146,11 +150,16 @@ class Jobi extends EventEmitter {
     const formattedLog = format( log );
 
     // Write the formatted log to the output stream. Always add a newline
-    const stream = levelValue > 3 ? this.stderr : this.stdout;
-    stream.write( formattedLog + '\n' );
+    if ( shouldLog ) {
+      const stream = levelValue > 3 ? this.stderr : this.stdout;
+      stream.write( formattedLog + '\n' );
+      this.emit( level, formattedLog, log );
+    }
 
-    // Emit an event for the given level
-    this.emit( level, formattedLog, log );
+    // Emit a "log" event if there are any listeners
+    if ( shouldEmit ) {
+      this.emit( 'log', level, formattedLog, log );
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "url": "https://github.com/StarryInternet/jobi/issues"
   },
   "homepage": "https://github.com/StarryInternet/jobi",
-  "engines" : { "node" : ">=8.3.0" },
+  "engines": {
+    "node": ">=8.3.0"
+  },
   "scripts": {
     "lint": "eslint .",
     "mocha": "NODE_ENV=test mocha test/tests --require test/globals.js  --recursive --exit",
@@ -28,14 +30,14 @@
     "test": "npm run lint && npm run nyc"
   },
   "devDependencies": {
-    "@starryinternet/eslint-config-starry": "9.2.0",
+    "@starryinternet/eslint-config-starry": "10.0.0",
     "@starryinternet/nyc-config-starry": "1.0.0",
-    "eslint-plugin-mocha": "7.0.1",
+    "eslint-plugin-mocha": "8.0.0",
     "chai": "4.2.0",
-    "eslint": "7.2.0",
-    "mocha": "7.2.0",
+    "eslint": "7.14.0",
+    "mocha": "8.2.1",
     "nyc": "15.1.0",
-    "sinon": "9.0.2"
+    "sinon": "9.2.1"
   },
   "nyc": {
     "extends": "@starryinternet/nyc-config-starry"

--- a/test/tests/lib/jobi.js
+++ b/test/tests/lib/jobi.js
@@ -304,5 +304,39 @@ describe( path, () => {
 
       logger[ logWithFormat ]( 'debug', formats.json, ...args );
     });
+
+    it( 'should not emit level event if level is insufficient', () => {
+      const logger = new Jobi( this.opts );
+      Jobi.level = 'error';
+      Jobi.format = 'json';
+
+      const args = [ 1, 'two', null, { four: 5, six: [ 7, '8' ] } ];
+
+      let emitted = false;
+      logger.once( 'info', () => {
+        emitted = true;
+      });
+
+      logger[ logWithFormat ]( 'info', formats.json, ...args );
+      assert.isFalse( emitted );
+    });
+
+    it( 'should emit "log" if listener even if level is insufficient', done => {
+      const logger = new Jobi( this.opts );
+      Jobi.level = 'error';
+      Jobi.format = 'json';
+
+      const args = [ 1, 'two', null, { four: 5, six: [ 7, '8' ] } ];
+      const expectedLog = buildLogObject( 'info', args );
+
+      logger.once( 'log', ( level, formatted, log ) => {
+        expect( level ).to.equal('info');
+        expect( log ).to.deep.equal( expectedLog );
+        expect( formatted ).to.equal( logger.format( expectedLog ) );
+        done();
+      });
+
+      logger[ logWithFormat ]( 'info', formats.json, ...args );
+    });
   });
 });


### PR DESCRIPTION
If there is a listener to a logging event, always emit an event, even if the log level is not sufficient. This is useful because applications / tests may want to receive ALL logs via events instead of only ones that are within the specified level. 

With this model, it is still possible to ignore logs by checking if the specified level is less than Jobi.level or removing the event listener.

_Note: This is a breaking change and will require a bump to `2.0.0`. However, this is a very low-impact change and should not break most applications._