### PR TITLE
Add shared prefix support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,12 @@ Get the current log format **OR** set the current log format for this `Jobi` ins
 `Log`:
 - `timestamp` (string)
 - `level` (string)
-- `message` (string | undefined)
+- `message` (string | undefined) *prefix is prepended to `message`*
 
+#### `logger.prefix` (string)
+
+Get the current log prefix of a Jobi instance. Prefixes can only be set in the
+constructor.
 
 #### `Jobi.level` (string)
 
@@ -71,9 +75,9 @@ Get the shared log format **OR** set the shared log format.
 
 ##### `opts`
 - `[format]` (string | (Log => string))
+- `[prefix]` (string)
 - `[stdout]` (stream.Writable)
 - `[stderr]` (stream.Writable)
-
 
 ##### Example
 ```js
@@ -105,6 +109,13 @@ since it automatically includes the other levels.
 Possible formats:
 - `pretty`
 - `json`
+
+#### Log Prefix
+
+A log prefix that will be prepended to the `message` property of a log object
+and can be set by passing the `prefix` prop to the Jobi constructor. Prefixes
+are added to all logs of Jobi instance. For different prefixes create separate
+instances.
 
 ### Events
 
@@ -144,7 +155,7 @@ logger.on( 'critical', msg => slack.notify( msg ) );
 logger.on( 'error', (msg, log) => {
   slack.notify(msg);
   console.error(log.stack);
-})
+});
 ```
 
 ##### Streaming
@@ -160,12 +171,22 @@ logger.stderr = file;
 logger.info('blah blah blah');
 ```
 
-##### Custom Jobi Instance
+##### Custom Log Format
 
 ```js
-const { Jobi } = require('@starryinternet/jobi')
+const { Jobi } = require('@starryinternet/jobi');
 const format = log => '>> ' + log.message || 'No message';
 
 const logger = new Jobi({ format });
 logger.info('Hello world'); // ">> Hello world"
+logger.info(); // ">> No message"
+```
+
+##### Custom Log Prefix
+```js
+const { Jobi } = require('@starryinternet/jobi');
+const prefix = 'logger: ';
+
+const logger = new Jobi({ prefix });
+logger.info('Hello world'); // "[2021-11-29T15:35:59.859Z] INFO: jobi: log message"
 ```

--- a/lib/jobi.js
+++ b/lib/jobi.js
@@ -8,7 +8,8 @@ const util         = require('./util');
 const DEFAULT_OPTS = {
   stdout: process.stdout,
   stderr: process.stderr,
-  format: null
+  format: null,
+  prefix: ''
 };
 
 // Shared Jobi settings symbols
@@ -16,8 +17,9 @@ const sharedLogLevel  = Symbol.for('JOBI_sharedLogLevel');
 const sharedLogFormat = Symbol.for('JOBI_sharedLogFormat');
 
 // Symbols for private properties and methods
-const logWithFormat   = Symbol.for('JOBI_logWithFormat');
-const localLogFormat  = Symbol.for('JOBI_localLogFormat');
+const logWithFormat  = Symbol.for('JOBI_logWithFormat');
+const localLogFormat = Symbol.for('JOBI_localLogFormat');
+const localLogPrefix = Symbol.for('JOBI_localLogPrefix');
 
 class Jobi extends EventEmitter {
   /**********/
@@ -57,7 +59,12 @@ class Jobi extends EventEmitter {
    */
   constructor( opts = {} ) {
     super();
-    const { stdout, stderr, format } = { ...DEFAULT_OPTS, ...opts };
+    const {
+      stdout,
+      stderr,
+      format,
+      prefix
+    } = { ...DEFAULT_OPTS, ...opts };
 
     if ( !( stdout instanceof Writable ) ) {
       throw new Error('stdout must be Writable');
@@ -70,6 +77,8 @@ class Jobi extends EventEmitter {
     this.stdout = stdout;
     this.stderr = stderr;
     this.format = format;
+
+    this[ localLogPrefix ] = prefix;
 
     // Ignore 'error' events to avoid Node process exiting
     this.on( 'error', () => {} );
@@ -111,6 +120,19 @@ class Jobi extends EventEmitter {
   }
 
   /**
+   * @type {string}
+   */
+  get prefix() {
+    return this[ localLogPrefix ];
+  }
+
+  set prefix( _ ) {
+    const msg = 'Do not set the prefix of a Jobi instance. ' +
+                'Instead, create a new instance.';
+    throw new Error( msg );
+  }
+
+  /**
    * Log the formatted level, message, and args to the appropriate stream
    *
    * @param {string} level - The level to log
@@ -147,6 +169,7 @@ class Jobi extends EventEmitter {
 
     // Aggregate and format the log into a writable string
     const log = util.buildLogObject( level, args );
+    log.message = this[ localLogPrefix ] + log.message;
     const formattedLog = format( log );
 
     // Write the formatted log to the output stream. Always add a newline

--- a/test/tests/lib/jobi.js
+++ b/test/tests/lib/jobi.js
@@ -1,10 +1,11 @@
 const fs           = require('fs');
 const { Writable } = require('stream');
-const path = 'lib/jobi';
-const Jobi = getModule( path );
-const formats = getModule('lib/formats');
+const path         = 'lib/jobi';
+
+const Jobi           = getModule( path );
+const formats        = getModule('lib/formats');
 const buildLogObject = getModule('lib/util/build-log-object');
-const levels = getModule('lib/levels');
+const levels         = getModule('lib/levels');
 
 // Shared Jobi settings symbols
 const sharedLogLevel  = Symbol.for('JOBI_sharedLogLevel');
@@ -95,6 +96,10 @@ describe( path, () => {
         expect( logger.format({ 'test': true }) ).to.equal('{"test":true}');
       });
 
+      it( 'should allow a custom prefix', () => {
+        new Jobi({ prefix: 'cognomen' });
+      });
+
       it( 'should set up correct defaults', () => {
         const logger = new Jobi();
         expect( logger.stdout ).to.deep.equal( process.stdout );
@@ -139,6 +144,18 @@ describe( path, () => {
       it( 'should throw on set', () => {
         const logger = new Jobi();
         assert.throws( () => logger.level = 'info' );
+      });
+    });
+
+    describe( 'prefix', () => {
+      it( 'should allow prefix to be read', () => {
+        const logger = new Jobi({ prefix: 'prefix' });
+        expect( logger.prefix ).to.equal('prefix');
+      });
+
+      it( 'should not allow prefix to be written', () => {
+        const logger = new Jobi({ prefix: 'prefix' });
+        assert.throws( () => logger.prefix = 'cognomen' );
       });
     });
 
@@ -284,6 +301,23 @@ describe( path, () => {
       const args = [ 1, 'two', null, { four: 5, six: [ 7, '8' ] } ];
       logger[ logWithFormat ]( 'info', format, ...args );
       const expected = buildLogObject( 'info', args );
+
+      expect( this.data ).to.equal( format( expected ) + '\n' );
+    });
+
+    it( 'should add prefix to log objects message prop', () => {
+      const logger = new Jobi({
+        ...this.opts,
+        prefix: 'prefix.'
+      });
+      Jobi.level = 'info';
+
+      const format = JSON.stringify;
+
+      const args = [ 1, 'two', null, { four: 5, six: [ 7, '8' ] } ];
+      logger[ logWithFormat ]( 'info', format, ...args );
+      const expected = buildLogObject( 'info', args );
+      expected.message = 'prefix.' + expected.message;
 
       expect( this.data ).to.equal( format( expected ) + '\n' );
     });


### PR DESCRIPTION
### Context
Adding simple prefixes to logs with Jobi was a bit of a pain using the `format` interface, so we decided to add a separate `prefix` interface.

### Implementation
The prefix itself is stored as a pseudo-private property on each `Jobi` instance using a `Symbol` as a key. The prefix is added in the constructor and cannot be changed after instantiation. The prefix is then added to logs with the `withPrefix` pseudo-private method. I decided not to add the `prefix` as a prop to the existing build log object since this could allow the prefix to end up in unexpected locations when using a custom `format` function and is not part of the log.

EDIT: I decided that using a separate `withPrefix` adds unnecessary complexity. Instead the `localLogPrefix` is prepended the message prop of every log with the default prefix being an empty string.